### PR TITLE
a way to hide github api key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Secrets lol :/
+buildSrc/src/main/java/Secrets.kt
+
 # Built application files
 *.apk
 *.ap_

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,13 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
+        getByName("debug") {
+            buildConfigField("String", "GITHUB_CLIENT_ID", Secrets.GITHUB_CLIENT_ID)
+            buildConfigField("String", "GITHUB_CLIENT_SECRET", Secrets.GITHUB_CLIENT_SECRET)
+        }
         getByName("release") {
+            buildConfigField("String", "GITHUB_CLIENT_ID", Secrets.GITHUB_CLIENT_ID)
+            buildConfigField("String", "GITHUB_CLIENT_SECRET", Secrets.GITHUB_CLIENT_SECRET)
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,7 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
+        // Secrets.kt is hidden in buildSrc/
         getByName("debug") {
             buildConfigField("String", "GITHUB_CLIENT_ID", Secrets.GITHUB_CLIENT_ID)
             buildConfigField("String", "GITHUB_CLIENT_SECRET", Secrets.GITHUB_CLIENT_SECRET)


### PR DESCRIPTION
add references to Github Client Application ID and Secret, and hide them by .gitignore.