### PR TITLE
remove work around for specifying kotlin jvmTarget version.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,9 +32,9 @@ android {
         sourceCompatibility = deps.versions.java
         targetCompatibility = deps.versions.java
     }
-//    kotlinOptions {
-//        jvmTarget = deps.versions.java.toString()
-//    }
+    kotlinOptions {
+        jvmTarget = deps.versions.java.toString()
+    }
     sourceSets {
         val commonTest = "src/test/java"
         getByName("androidTest").java.srcDirs(commonTest)
@@ -124,12 +124,4 @@ dependencies {
     androidTestImplementation(deps.android.test.junit)
     androidTestImplementation(deps.android.test.runner)
     androidTestImplementation(deps.android.test.core)
-}
-
-// TODO: move this into android when https://github.com/gradle/kotlin-dsl-samples/issues/1368
-//  resolved.
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
 }


### PR DESCRIPTION
https://github.com/gradle/kotlin-dsl-samples/issues/1368 has been resolved